### PR TITLE
Add fallback to the example for handling chi-squared warnings

### DIFF
--- a/vignettes/table1-examples.Rmd
+++ b/vignettes/table1-examples.Rmd
@@ -454,8 +454,13 @@ pvalue <- function(x, ...) {
         # For numeric variables, perform a standard 2-sample t-test
         p <- t.test(y ~ g)$p.value
     } else {
-        # For categorical variables, perform a chi-squared test of independence
-        p <- chisq.test(table(y, g))$p.value
+        p <- tryCatch({
+            # For categorical variables, perform a chi-squared test of independence
+            chisq.test(table(y, g))$p.value
+        }, warning = function(w) {
+            # If a warning appears (due to expected cell counts <5 or too few observations), use Fisher's Exact test
+            return(fisher.test(table(y, g))$p.value)
+        })
     }
     # Format the p-value, using an HTML entity for the less-than sign.
     # The initial empty string places the output on the line below the variable label.


### PR DESCRIPTION
I saw someone run into this earlier and I thought it would be helpful to update the example to handle [this case](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5426219/#:~:text=While%20the%20chi%2Dsquared%20test,applying%20approximation%20method%20is%20inadequate)