### PR TITLE
moved footnote to after </tbody> in update_html

### DIFF
--- a/R/table1.R
+++ b/R/table1.R
@@ -1098,10 +1098,11 @@ update_html <- function(x) {
             sprintf('<table%s>%s\n<thead>\n', topclass, caption),
             thead0,
             table.rows(thead, row.labels=rowlabelhead, th=T),
-            tfoot,
             '</thead>\n<tbody>\n',
             paste(sapply(contents, table.rows), collapse=""),
-            '</tbody>\n</table>\n')
+            '</tbody>\n',
+            tfoot,
+            '</table>\n')
 
         structure(x, class=c("table1", "html", "character"), html=TRUE, obj=obj)
     })


### PR DESCRIPTION
![image](https://github.com/benjaminrich/table1/assets/121236675/472ac026-8910-4398-a726-ca5ea0358e18)

Small tweak to get the footnote to display at the bottom of the table when pasted to a spreadsheet application. Previously the footnote displayed before table body. Screenshot shows results before tweak and after tweak using Microsoft Excel:
```
table1(~mpg+cyl+disp, 
       data=mtcars,
       footnote='This is a test footnote')
```

Thank you for the package, I use it all the time, it's fantastic!