### PR TITLE
Fix argument droplevels=FALSE ignored for table1.formula

### DIFF
--- a/R/table1.R
+++ b/R/table1.R
@@ -1513,7 +1513,7 @@ table1.formula <- function(x, data, overall="Overall", rowlabelhead="", transpos
         if (any(sapply(m2, function(xx) any(is.na(xx))))) {
             stop("Stratification variable(s) should not contain missing values.")
         }
-        m2 <- lapply(m2, factorp)
+        m2 <- lapply(m2, function(x) factorp(x, levels = levels(x)))
         if (droplevels) {
             m2 <- lapply(m2, droplevels)
         }


### PR DESCRIPTION
The argument droplevels of the table1.formula function was ignored. For example in the code below:

```
library(table1)

data <- mtcars
data$cyl <- as.factor(data$cyl)
levels(data$cyl) <- c(levels(data$cyl), "Unused")

print(table1(data = data, x = ~ gear | cyl, droplevels = FALSE))
```
we would expect the column "Unused" to appear in the resulting table, but this is not the case. 

The issue was introduced in c0a31d2 where the line 1516 in table1.R was changed from `m2 <- lapply(m2, as.factor)` to `m2 <- lapply(m2, factorp)`. The first one preserves the levels of the source columns, while the second does not. 

PS: thanks for such a nice package =).
